### PR TITLE
update websocket uri to use wss if https is in the Server.public_url

### DIFF
--- a/src/textual_serve/server.py
+++ b/src/textual_serve/server.py
@@ -1,22 +1,27 @@
 from __future__ import annotations
 
 import asyncio
+
 import logging
 import os
+from pathlib import Path
 import signal
 import sys
-from importlib.metadata import version
-from pathlib import Path
+
 from typing import Any
 
 import aiohttp_jinja2
-import jinja2
-from aiohttp import WSMsgType, web
+from aiohttp import web
+from aiohttp import WSMsgType
 from aiohttp.web_runner import GracefulExit
+import jinja2
+
+from importlib.metadata import version
+
 from rich import print
 from rich.console import Console
-from rich.highlighter import RegexHighlighter
 from rich.logging import RichHandler
+from rich.highlighter import RegexHighlighter
 
 from .app_service import AppService
 
@@ -25,9 +30,7 @@ log = logging.getLogger("textual-serve")
 LOGO = r"""[bold magenta]___ ____ _  _ ___ _  _ ____ _       ____ ____ ____ _  _ ____ 
  |  |___  \/   |  |  | |__| |    __ [__  |___ |__/ |  | |___ 
  |  |___ _/\_  |  |__| |  | |___    ___] |___ |  \  \/  |___ [not bold]VVVVV
-""".replace(
-    "VVVVV", f"v{version('textual-serve')}"
-)
+""".replace("VVVVV", f"v{version('textual-serve')}")
 
 
 WINDOWS = sys.platform == "WINDOWS"


### PR DESCRIPTION
After testing with an public https with certs I got this in the browser:
```
index.js:143 Uncaught (in promise) DOMException: Failed to construct 'WebSocket': An insecure WebSocket connection may not be initiated from a page loaded over HTTPS.
    at TextualTerminal.connect (webpack://textual/./src/index.js?:143:19)
    at eval (webpack://textual/./src/index.js?:221:24)
    at NodeList.forEach (<anonymous>)
    at window.onload (webpack://textual/./src/index.js?:214:13)
connect @ index.js:143
eval @ index.js:221
window.onload @ index.js:214
load (async)
eval @ index.js:205
./src/index.js @ textual.js:179
__webpack_require__ @ textual.js:203
(anonymous) @ textual.js:260
(anonymous) @ textual.js:262
```


This seems to be because the websockets are hardcoded to use `ws` instead of `wss`.